### PR TITLE
Missing requirements added to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,10 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/dotenv": "^4.0 || ^5.0"
+        "symfony/dotenv": "^4.0 || ^5.0",
+        "symfony/cache": "^4.0 || ^5.0",
+        "symfony/process": "^4.0 <5.0",
+        "symfony/yaml": "^4.0 || ^5.0"
     },
     "autoload": {
         "psr-4": { "Brannow\\Component\\Envyml\\": "" }


### PR DESCRIPTION
Some Symfony packages were used without requiring them in the composer.json.

In line 489 the method `inheritEnvironmentVariables` was removed from `symfony/process` in version 5.0, it is therefore not compatible with this package right now.